### PR TITLE
Add ClassSchedule and Course schemas with validation using zod

### DIFF
--- a/src/lib/schema/ClassSchedule.ts
+++ b/src/lib/schema/ClassSchedule.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-export const route = (classScheduleId: string) => `/course/${classScheduleId}`;
+export const route = (classScheduleId: string) => `/classSchedule/${classScheduleId}`;
 
 export const ClassSchedule = z.object({
-	uuid: z.uuid().describe('Unique identifier for the class schedule'),
+    uuid: z.uuid().describe('Unique identifier for the class schedule'),
     name: z.string().min(1).max(64).describe('Name of the class schedule').optional(), // if it is undefined, set in frontend
     year: z.number().describe('Academic year'),
     semester: z.number().describe('Semester'),

--- a/src/lib/schema/ClassSchedule.ts
+++ b/src/lib/schema/ClassSchedule.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const route = (classScheduleId: string) => `/course/${classScheduleId}`;
+
+export const ClassSchedule = z.object({
+	uuid: z.uuid().describe('Unique identifier for the class schedule'),
+    name: z.string().min(1).max(64).describe('Name of the class schedule').optional(), // if it is undefined, set in frontend
+    year: z.number().describe('Academic year'),
+    semester: z.number().describe('Semester'),
+    visibility: z.enum(['private', "friendsOnly", "linkOnly", 'public']).describe('Visibility of the class schedule').default('private'),
+    courses: z.array(z.uuid()).describe('Array of course UUIDs').default([]),
+});
+
+export type ClassSchedule = z.infer<typeof ClassSchedule>;

--- a/src/lib/schema/Course.ts
+++ b/src/lib/schema/Course.ts
@@ -8,9 +8,9 @@ export const CourseSchema = z.object({
 	course_classroom: z.string().min(0).max(16).describe('Classroom location'), // can be empty "" string
 	course_year: z.number().describe('Academic year'),
 	course_semester: z.number().describe('Semester'),
-	course_credit: z.number().describe('Course credit'), 
+	course_credit: z.number().describe('Course credit'),
 	course_number: z.string().min(1).max(16).describe('Course number').optional(),
-	course_name_zh: z.string().min(1).max(32).describe('Course name in Chinese').optional(), 
+	course_name_zh: z.string().min(1).max(32).describe('Course name in Chinese').optional(),
 	course_name_en: z.string().min(1).max(128).describe('Course name in English').optional(),
 	course_provider: z.array(z.string().min(1).max(64)).describe('Course provider').optional(),
 	course_department: z.string().min(1).max(32).describe('Course department'),

--- a/src/lib/schema/Course.ts
+++ b/src/lib/schema/Course.ts
@@ -1,0 +1,32 @@
+
+import { z } from 'zod';
+
+export const route = (courseId: string) => `/course/${courseId}`;
+
+export const CourseSchema = z.object({
+	uuid: z.uuid().describe('Unique identifier for the course'),
+	course_classroom: z.string().min(0).max(16).describe('Classroom location'), // can be empty "" string
+	course_year: z.number().describe('Academic year'),
+	course_semester: z.number().describe('Semester'),
+	course_credit: z.number().describe('Course credit'), 
+	course_number: z.string().min(1).max(16).describe('Course number').optional(),
+	course_name_zh: z.string().min(1).max(32).describe('Course name in Chinese').optional(), 
+	course_name_en: z.string().min(1).max(128).describe('Course name in English').optional(),
+	course_provider: z.array(z.string().min(1).max(64)).describe('Course provider').optional(),
+	course_department: z.string().min(1).max(32).describe('Course department'),
+	course_time: z.array(
+		z.object({
+			start: z.string().regex(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)-([01]\d|2[0-3]):([0-5]\d)$/).describe('Start time in format <Weekday>-<hour>:<minute> ex: Mon-09:00'),
+			end: z.string().regex(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)-([01]\d|2[0-3]):([0-5]\d)$/).describe('End time in format <Weekday>-<hour>:<minute> ex: Mon-10:00')
+		})
+	).describe('Course time').default([]), // [] is also valid
+	update_at: z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2}|Z)$/).describe('Last update time in ISO 8601 format'),
+	emi: z.boolean().describe('Whether the course is EMI (English as Medium of Instruction)').default(false),
+	course_category: z.enum(["Compulsory", "Elective", "GeneralEducation", "PE", "MilitaryTraining", "TeacherEducation", "Other"]).describe('Course category').default("Other"),
+	course_student_count: z.number().describe('Number of students enrolled'),
+	url: z.url().min(1).max(2048).describe('Course URL').optional(),
+	others: z.string().min(1).max(1024).describe('Other information').optional(),
+	exist: z.boolean().describe('Whether the course still exists').default(true)
+});
+
+export type Course = z.infer<typeof CourseSchema>;


### PR DESCRIPTION
This pull request introduces two new schema definitions using Zod for class schedules and courses, providing strong typing and validation for these entities. These schemas will help ensure data integrity and consistency across the application.

**Class Schedule Schema:**

* Added `ClassSchedule` schema in `src/lib/schema/ClassSchedule.ts` with fields for UUID, name, year, semester, visibility, and course UUIDs.
* Defined a route helper function for class schedules.

**Course Schema:**

* Added `CourseSchema` in `src/lib/schema/Course.ts` with detailed validation for course properties such as classroom, year, semester, credit, names, provider, department, schedule, last update time, EMI status, category, student count, URL, other info, and existence.
* Defined a route helper function for courses.